### PR TITLE
Make suprb2 work for Python3.8.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # SupRB-2
 
+## Install all requirements: 
+pip3 install -r suprb2/requirements.txt

--- a/main.py
+++ b/main.py
@@ -36,12 +36,12 @@ def plot_results(X, y_test, y_pred, elitist=None, saveas=None):
             plt.axvline(elitist.get_classifiers()[i].upperBounds[0],
                         color=colors[i % len(colors)], lw=1.5)
             ax.add_patch(Rectangle((elitist.get_classifiers()[i].lowerBounds[
-                                        0], np.min(y_test)+i*per_cl),
-                                   elitist.get_classifiers()[i].upperBounds[
-                                       0]-elitist.get_classifiers()[
-                                       i].lowerBounds[0], per_cl, fill=False,
-                                   linewidth=2, edgecolor=colors[i % len(colors)],
-                                   hatch='/'))
+                0], np.min(y_test)+i*per_cl),
+                elitist.get_classifiers()[i].upperBounds[
+                0]-elitist.get_classifiers()[
+                i].lowerBounds[0], per_cl, fill=False,
+                linewidth=2, edgecolor=colors[i % len(colors)],
+                hatch='/'))
 
     plt.legend()
 
@@ -104,7 +104,7 @@ if __name__ == '__main__':
     X, y = prob.generate(n)
 
     y = np.reshape(y, (-1, 1))
-    
+
     xdim = prob.xdim + prob.adim"""
 
     Random().reseed(0)
@@ -150,4 +150,3 @@ if __name__ == '__main__':
             print(f"Finished at {datetime.now().time()}. RMSE was {np.sqrt(error)}")
 
     pass
-

--- a/suprb2/requirements.txt
+++ b/suprb2/requirements.txt
@@ -1,4 +1,5 @@
 numpy~=1.20.1
 pandas~=1.1.3
 scikit-learn~=0.23.2
-mlflow~=1.11
+mlflow~=1.15
+matplotlib~=3.4.0


### PR DESCRIPTION
- Remove **main**-folder
- Update Readme
- Update requirements.txt for Python 3.8.5
- Autoformat **main.py** with auto-pep

Explanation: Python3.8 uses the **main**-file and looks in that directory to find local modules. By having **main.py** inside the **main**-folder Python3.8 doesn't "see" any files besides **main.py**. By moving **main.py** to the parent directory the issue is resolved